### PR TITLE
Update Monokai.tmTheme with String Interpretation. 

### DIFF
--- a/Themes/Monokai.tmTheme
+++ b/Themes/Monokai.tmTheme
@@ -293,6 +293,30 @@
 				<string>#F8F8F0</string>
 			</dict>
 		</dict>
+                        <dict>
+                                <key>name</key>
+                                <string>String interpolation</string>
+                                <key>scope</key>
+                                <string>constant.character.escape, string source</string>
+                                <key>settings</key>
+                                <dict>
+                                        <key>fontStyle</key>
+                                        <string></string>
+                                        <key>foreground</key>
+                                        <string>#2FE420</string>
+                                </dict>
+                        </dict>
+                        <dict>
+                                <key>name</key>
+                                <string>Embedded source</string>
+                                <key>scope</key>
+                                <string>text source, string.unquoted, meta.embedded</string>
+                                <key>settings</key>
+                                <dict>
+                                        <key>background</key>
+                                        <string>#49483E</string>
+                                </dict>
+                        </dict>
 	</array>
 	<key>uuid</key>
 	<string>D8D5E82E-3D5B-46B5-B38E-8C841C21347D</string>


### PR DESCRIPTION
Added colorization for String interpolation and embedded source code.  (For things like javascript literals.)

![screen shot 2017-10-05 at 2 54 19 pm](https://user-images.githubusercontent.com/458367/31246966-1d6a982e-a9dd-11e7-944b-85ef54794433.png)
